### PR TITLE
Fix Tenant email regex

### DIFF
--- a/APT-Market/Models/Tenant.cs
+++ b/APT-Market/Models/Tenant.cs
@@ -14,7 +14,7 @@ public class Tenant
     [RegularExpression(@"^\+?[0-9]{9,11}$", ErrorMessage = "Nieprawidłowy numer telefonu.")]
     public string PhoneNumber { get; set; }
     [Required(ErrorMessage = "Adres email jest wymagany.")]
-    [RegularExpression(@"^[^@\s]+@[^@\s].[^@\s]+$", ErrorMessage = "Nieprawidłowy format adresu email.")]
+    [RegularExpression(@"^[^@\s]+@[^@\s]+\.[^@\s]+$", ErrorMessage = "Nieprawidłowy format adresu email.")]
     public string Email { get; set; }
     public ICollection<RentalAgreement> RentalAgreements { get; set; } = new List<RentalAgreement>();
     public ICollection<Payment> Payments { get; set; } = new List<Payment>();


### PR DESCRIPTION
## Summary
- update tenant email validation regex

## Testing
- `python3 - <<'EOF'
import re
pattern = r'^[^@\s]+@[^@\s]+\.[^@\s]+$'
print(re.match(pattern, 'example@example.com') is not None)
EOF`


------
https://chatgpt.com/codex/tasks/task_e_687ebeaca54483228317f738fac3c440