### PR TITLE
Fix RentalAgreement end date validation

### DIFF
--- a/APT-Market/Models/RentalAgreement.cs
+++ b/APT-Market/Models/RentalAgreement.cs
@@ -25,7 +25,7 @@ public class RentalAgreement : IValidatableObject
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-        if (StartDate > EndDate)
+        if (EndDate.HasValue && StartDate > EndDate.Value)
         {
             yield return new ValidationResult(
                 "Data musi zostać poprawnie wprowadzona (zakończenie najmu nie może być przed jego rozpoczęciem)",


### PR DESCRIPTION
## Summary
- check `EndDate.HasValue` before comparing start and end dates in `RentalAgreement.Validate`

## Testing
- `dotnet build APT-Market/APT-Market.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec1b9659c8322b1d9f4f147a539bd